### PR TITLE
EDGE-1097 initial commit, stringified the error object to give a bit more info on the error

### DIFF
--- a/src/v3/signaling.ts
+++ b/src/v3/signaling.ts
@@ -62,7 +62,8 @@ class Signaling extends EventEmitter {
       });
 
       ws.on("error", (error) => {
-        logger.error(`Websocket error: ${error}`);
+        // TODO: make this a more informative error message
+        logger.error(`Websocket error: ${JSON.stringify(error)}`);
         if (this.pingInterval) {
           clearInterval(this.pingInterval);
         }


### PR DESCRIPTION
After some exhaustive research on my part, determined that at this time there isn't much more we can do to pull a baked in error message and/or code from this particular error event. We are stringifying the object to give a little more info, but this is all we can do for now.