### PR TITLE
EDGE-920 resetting hasSetMediaPreferences to false when disconnect is called

### DIFF
--- a/src/v3/signaling.ts
+++ b/src/v3/signaling.ts
@@ -85,6 +85,8 @@ class Signaling extends EventEmitter {
         const finalDiagnostics = this.diagnosticsBatcher.getDiagnostics();
         this.sendDiagnostics(finalDiagnostics);
       }
+      logger.debug("Setting hasSetMediaPreferences to false");
+      this.hasSetMediaPreferences = false;
       this.ws.removeAllListeners();
       this.ws.close();
       this.ws = null;


### PR DESCRIPTION
Making sure hasSetMediaPreferences is set to false whenever disconnect is called because if disconnect is called the user is likely prepared to stop receiving media